### PR TITLE
Add error checking, shorten code logic

### DIFF
--- a/N-FC_patchmon.sh
+++ b/N-FC_patchmon.sh
@@ -18,11 +18,9 @@ function PullPatchData
     while [ -z "$buildid" ]; do
         echo "DEBUG: Pulling Patch Data from Steam"
         bash $SteamcmdDirectory/steamcmd.sh +login anonymous +app_info_print 2353090 +quit > $SCRIPT_DIR/temp/steamoutput.txt
-    
         echo "DEBUG: Extracting Build ID"
         buildid=$(grep -A 3 $MonitorBranch $SCRIPT_DIR/temp/steamoutput.txt | grep '"buildid"' | awk '{print $2}' | tr -d '"')
     done
-
     echo "DEBUG: $MonitorBranch Build ID is currently: $buildid"
 }
 

--- a/N-FC_patchmon.sh
+++ b/N-FC_patchmon.sh
@@ -14,22 +14,16 @@ source $SCRIPT_DIR/config.txt
 ######### FUNCTIONS
 function PullPatchData
 {
-    echo "DEBUG: Pulling Patch Data from Steam"
-    bash $SteamcmdDirectory/steamcmd.sh +login anonymous +app_info_print 2353090 +quit > $SCRIPT_DIR/temp/steamoutput.txt
-}
 
-function ExtractBuildID_public
-{
-    echo "DEBUG: Extracting Public Build ID"
-    buildid_public=$(grep -A 3 '"public"' $SCRIPT_DIR/temp/steamoutput.txt | grep '"buildid"' | awk '{print $2}' | tr -d '"')
-    echo "DEBUG: Public Build ID is currently: $buildid_public"
-}
+    while [ -z "$buildid" ]; do
+        echo "DEBUG: Pulling Patch Data from Steam"
+        bash $SteamcmdDirectory/steamcmd.sh +login anonymous +app_info_print 2353090 +quit > $SCRIPT_DIR/temp/steamoutput.txt
+    
+        echo "DEBUG: Extracting Build ID"
+        buildid=$(grep -A 3 $MonitorBranch $SCRIPT_DIR/temp/steamoutput.txt | grep '"buildid"' | awk '{print $2}' | tr -d '"')
+    done
 
-function ExtractBuildID_testing
-{
-    echo "DEBUG: Extracting Testing Build ID"
-    buildid_testing=$(grep -A 3 '"testing"' $SCRIPT_DIR/temp/steamoutput.txt | grep '"buildid"' | awk '{print $2}' | tr -d '"')
-    echo "DEBUG: Testing Build ID is currently: $buildid_testing"
+    echo "DEBUG: $MonitorBranch Build ID is currently: $buildid"
 }
 
 ####### Main Execution
@@ -41,61 +35,35 @@ else
     echo "DEBUG: Directory '$SCRIPT_DIR/temp' already exists."
 fi
 
+#Make Sure MonitorBranch is set to a valid option
+if [ "$MonitorBranch" = 'public' ]; then
+    echo "DEBUG: Monitoring Public Branch"
+elif [ "$MonitorBranch" = 'testing' ]; then
+    echo "DEBUG: Monitoring Test Branch"
+else
+    echo "DEBUG: Branch Monitor configuration variable incorrect, only the following branches are currently supported: public | testing"
+    exit 1
+fi
+
 #Check if this is the first-run
-if [ ! -f "$SCRIPT_DIR/temp/current_build_id.txt" ]; then
+if [ ! -f "$SCRIPT_DIR/temp/current_build_id.txt" ]; then 
     echo "DEBUG: Script has not executed previously. Initializing with initial build_id seeding"
     PullPatchData
-    if [ "$MonitorBranch" = 'public' ]
-    then
-        ExtractBuildID_public
-        echo $buildid_public > $SCRIPT_DIR/temp/current_build_id.txt
-        exit 0
-    elif [ "$MonitorBranch" = 'testing' ]
-    then
-        ExtractBuildID_testing
-        echo $buildid_testing > $SCRIPT_DIR/temp/current_build_id.txt
-        exit 0
-    else
-        echo "DEBUG: Branch Monitor configuration variable incorrect, only the following branches are currently supported: public | testing"
-        exit 1
-    fi
+    echo "current_build_id=$buildid" > $SCRIPT_DIR/temp/current_build_id.txt
+    exit 0
 else
     echo "DEBUG: Script has been executed previously. Continuing."
 fi
 
-#Pull Current Patch Data
-PullPatchData
-
 #Main Check
-if [ "$MonitorBranch" = "public" ]
-then
-    echo "DEBUG: Monitoring Public Branch"
-    ExtractBuildID_public
-    if [ "$buildid_public" -le $(cat $SCRIPT_DIR/temp/current_build_id.txt) ]
-    then
-        echo "Build IDs match, no changes to upstream. Exiting Script."
-        exit 0
-    else
-        echo "Build ID's DO NOT match, calling ASRU Patch Script to update server baseline"
-        bash $SCRIPT_DIR/N-FC_ASRU.sh restart patching
-        echo $buildid_public > $SCRIPT_DIR/temp/current_build_id.txt
-        exit 0
-    fi
-elif [ "$MonitorBranch" = "testing" ]
-then
-    echo "DEBUG: Monitoring Testing Branch"
-    ExtractBuildID_testing
-    if [ "$buildid_testing" -le $(cat $SCRIPT_DIR/temp/current_build_id.txt) ]
-    then
-        echo "Build IDs match, no changes to upstream. Exiting Script."
-        exit 0
-    else
-        echo "Build ID's DO NOT match, calling ASRU Patch Script to update server baseline"
-        bash $SCRIPT_DIR/N-FC_ASRU.sh restart patching
-        echo $buildid_testing > $SCRIPT_DIR/temp/current_build_id.txt
-        exit 0
-    fi
+PullPatchData
+source $SCRIPT_DIR/temp/current_build_id.txt
+if [ "$buildid" -le $current_build_id ]; then
+    echo "Build IDs match, no changes to upstream. Exiting Script."
+    exit 0
 else
-    echo "DEBUG: Branch Monitor configuration variable incorrect, only the following branches are currently supported: public | testing"
-    exit 1
+    echo "Build ID's DO NOT match, calling ASRU Patch Script to update server baseline"
+    bash $SCRIPT_DIR/N-FC_ASRU.sh restart patching
+    echo "current_build_id=$buildid" > $SCRIPT_DIR/temp/current_build_id.txt
+    exit 0
 fi


### PR DESCRIPTION
Fixed a few issues. Namely a transient issue where SteamCMD would not push out a valid build ID which can cause script to lock up. Now it will retry until it has a valid variable. Also cleaned up code logic so there's no repeat code for different branches. 